### PR TITLE
Fixed the broken images showing up in product catalog when creating a…

### DIFF
--- a/frontend/src/components/Editor.js
+++ b/frontend/src/components/Editor.js
@@ -53,8 +53,9 @@ class Editor extends React.Component {
       // If the image url is empty, placeholder image is shown instead
       let imageUrl = this.props.image;
       if (imageUrl.trim() === "") {
-        imageUrl = "placeholder.png"
-      } 
+        this.props.onUpdateField("image", "placeholder.png");
+        imageUrl = "placeholder.png";
+      }
 
       const item = {
         title: this.props.title,

--- a/frontend/src/components/Editor.js
+++ b/frontend/src/components/Editor.js
@@ -49,10 +49,17 @@ class Editor extends React.Component {
 
     this.submitForm = (ev) => {
       ev.preventDefault();
+
+      // If the image url is empty, placeholder image is shown instead
+      let imageUrl = this.props.image;
+      if (imageUrl.trim() === "") {
+        imageUrl = "placeholder.png"
+      } 
+
       const item = {
         title: this.props.title,
         description: this.props.description,
-        image: this.props.image,
+        image: imageUrl,
         tagList: this.props.tagList,
       };
 

--- a/frontend/src/components/Editor.js
+++ b/frontend/src/components/Editor.js
@@ -47,20 +47,23 @@ class Editor extends React.Component {
       this.props.onRemoveTag(tag);
     };
 
+    this.resolveImageUrl = () => {
+      let imageUrl = this.props.image;
+      if (imageUrl.trim() === "") {
+        this.props.onUpdateField("image", "placeholder.png");
+      }
+    };
+
     this.submitForm = (ev) => {
       ev.preventDefault();
 
       // If the image url is empty, placeholder image is shown instead
-      let imageUrl = this.props.image;
-      if (imageUrl.trim() === "") {
-        this.props.onUpdateField("image", "placeholder.png");
-        imageUrl = "placeholder.png";
-      }
+      this.resolveImageUrl();
 
       const item = {
         title: this.props.title,
         description: this.props.description,
-        image: imageUrl,
+        image: this.props.image,
         tagList: this.props.tagList,
       };
 
@@ -73,7 +76,7 @@ class Editor extends React.Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate(nextProps) {
     if (this.props.match.params.slug !== nextProps.match.params.slug) {
       if (nextProps.match.params.slug) {
         this.props.onUnload();

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -20,6 +20,10 @@ const mapDispatchToProps = (dispatch) => ({
 const ItemPreview = (props) => {
   const item = props.item;
 
+  if (item.image.trim() === "") {
+    item.image = "placeholder.png";
+  }
+
   const handleClick = (ev) => {
     ev.preventDefault();
     if (item.favorited) {

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -20,7 +20,7 @@ const mapDispatchToProps = (dispatch) => ({
 const ItemPreview = (props) => {
   const item = props.item;
 
-  if (item.image.trim() === "") {
+  if (item.image === "") {
     item.image = "placeholder.png";
   }
 

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -20,10 +20,6 @@ const mapDispatchToProps = (dispatch) => ({
 const ItemPreview = (props) => {
   const item = props.item;
 
-  if (item.image === "") {
-    item.image = "placeholder.png";
-  }
-
   const handleClick = (ev) => {
     ev.preventDefault();
     if (item.favorited) {
@@ -40,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || "placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
… new product without an image

When the url of the image was empty, **this.props.image** was empty hence the images in the catalog broke. I added a check that if the image url is not provided, the default image (placeholder.png) is used.

![Screenshot from 2022-08-02 10-01-40](https://user-images.githubusercontent.com/32712842/182295560-8292483a-9e88-4212-a2da-d982433a5ff0.png)

